### PR TITLE
Add support for Kerberos authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ nosetests.xml
 .DS_Store
 *.pyc
 test.py
+.idea
+venv

--- a/pyhs2/test/test_kerberos.py
+++ b/pyhs2/test/test_kerberos.py
@@ -1,0 +1,25 @@
+import unittest
+from pyhs2.connections import Connection
+
+@unittest.skip("These are not proper unit tests. A secure hive server is required to actually execute them.")
+class KerberosTest(unittest.TestCase):
+
+    def create_conn(self):
+        return Connection(host="secure.hiveserver2.fqdn", user="kerberos_principal@realm", password="password", authMechanism="KERBEROS")
+
+    def test_meta(self):
+        with(self.create_conn()) as conn:
+            with(conn.cursor()) as cur:
+                databases = cur.getDatabases()
+                print(databases)
+                self.assertIsNotNone(databases)
+                self.assertGreater(len(databases), 0)
+
+    def test_querying(self):
+        with(self.create_conn()) as conn:
+            with(conn.cursor()) as cur:
+                cur.execute("SELECT count(*) FROM test_table")
+                record = cur.fetch()
+                print(record)
+                self.assertIsNotNone(record)
+                self.assertGreater(len(record), 0)


### PR DESCRIPTION
This is a patch to support Kerberos authentication on Kerberized Hive Server installations.
Additionally, exposed the `configuration` dict to be passed to the Hive session manager. (AFAIK, currently only useful for specifiying `hive.server2.proxy.user` setting in setups that require it)
