### PR TITLE
add username and password to argument of TOpenSessionReq constructor.

### DIFF
--- a/pyhs2/connections.py
+++ b/pyhs2/connections.py
@@ -43,7 +43,7 @@ class Connection(object):
 
         self.client = TCLIService.Client(TBinaryProtocol(transport))
         transport.open()
-        res = self.client.OpenSession(TOpenSessionReq(configuration=configuration))
+        res = self.client.OpenSession(TOpenSessionReq(username=user, password=password, configuration=configuration))
         self.session = res.sessionHandle
         if database is not None:
             with self.cursor() as cur:


### PR DESCRIPTION
Hi

I use CDH 4.5+hiveserver2(hive 0.10)+NOSASL.

I try to connect hiveserver2 with pyhs2+python 2.7.6.

but "Required field 'sessionHandle' is unset!" error occurs if I try to connects hiveserver2 with pyhs2+NOSASL+username in the following python code, 

```
import pyhs2

conn = pyhs2.connect(host='...', port=10000, authMechanism="NOSASL", user='...')
cur = conn.cursor()
cur.execute("select * from ... limit 10")
for i in cur.fetch():
        print i
cur.close()
conn.close()
```

Traceback is the following.

```
Traceback (most recent call last):
  File "aaa.py", line 9, in <module>
    cur.execute("select * from ... limit 10")
  File "/../python-2.7.6/lib/python2.7/site-packages/pyhs2/cursor.py", line 50, in execute
    res = self.client.ExecuteStatement(query)
  File "/.../python-2.7.6/lib/python2.7/site-packages/pyhs2/TCLIService/TCLIService.py", line 244, in ExecuteStatement
    return self.recv_ExecuteStatement()
  File "/.../python-2.7.6/lib/python2.7/site-packages/pyhs2/TCLIService/TCLIService.py", line 260, in recv_ExecuteStatement
    raise x
thrift.Thrift.TApplicationException: Required field 'sessionHandle' is unset! Struct:TExecuteStatementReq(sessionHandle:null, statement:select * from ... limit 10, confOverlay:{})
```

If I add username and password to argument of TOpenSessionReq constructor, the problem is solved.
So I send pull request.

but I don't test at PLAIN and KERBEROS and LDAP environment.
