### PR TITLE
Adding "Streaming" cursor functionality

### DIFF
--- a/pyhs2/connections.py
+++ b/pyhs2/connections.py
@@ -16,7 +16,7 @@ class Connection(object):
     client = None
     session = None
 
-    def __init__(self, host=None, port=10000, authMechanism=None, user=None, password=None, database=None, configuration=None):
+    def __init__(self, host=None, port=10000, authMechanism=None, user=None, password=None, database=None, configuration=None, cursorclass=Cursor):
         authMechanisms = set(['NOSASL', 'PLAIN', 'KERBEROS', 'LDAP'])
         if authMechanism not in authMechanisms:
             raise NotImplementedError('authMechanism is either not supported or not implemented')
@@ -69,8 +69,10 @@ class Connection(object):
 
         return host, service
 
-    def cursor(self):
-        return Cursor(self.client, self.session)
+    def cursor(self, cursor = None):
+        if cursor:
+            return cursor(self.client, self.session)
+        return self.cursorclass(self.client, self.session)
 
     def close(self):
         req = TCloseSessionReq(sessionHandle=self.session)


### PR DESCRIPTION
When pulling result rows from Thrift, the current cursor attempts to load them all into a single variable which it then returns. This can cause major issues with large result sets; I've implemented a cursor class which returns a generator object and iterates over each result row.  

Example usage:

from cursor import SSCursor

conn = pyhs2.connect(cursorclass=SSCursor, **kwargs)
cur = conn.cursor()
cur.execute("SELECT \* FROM table LIMIT 100")
for result in cur.fetch():
...print result
