### PR TITLE
fix second calling fetch method at same cursor object always return []

### DIFF
--- a/pyhs2/cursor.py
+++ b/pyhs2/cursor.py
@@ -56,6 +56,7 @@ class Cursor(object):
         self._cursorLock = threading.RLock()
 
     def execute(self, hql):
+        self.hasMoreRows = True
         query = TExecuteStatementReq(self.session, statement=hql, confOverlay={})
         res = self.client.ExecuteStatement(query)
         self.operationHandle = res.operationHandle


### PR DESCRIPTION
set hasMoreRows=True at cursor#execute

If you call execute/fetch method twice at same cursor object, second fetch always return [] because hasMoreRows is True.

This is not good.

for example,
cur.execute("select \* from hoge")
print cur.fetch()
cur.execute("select \* from piyo")
print cur.fetch() # always []
