### PR TITLE
Add new data types for the Thrift Client

### DIFF
--- a/pyhs2/TCLIService/ttypes.py
+++ b/pyhs2/TCLIService/ttypes.py
@@ -44,6 +44,10 @@ class TTypeId:
   UNION_TYPE = 13
   USER_DEFINED_TYPE = 14
   DECIMAL_TYPE = 15
+  NULL_TYPE = 16
+  DATE_TYPE = 17
+  VARCHAR_TYPE = 18
+  CHAR_TYPE = 19
 
   _VALUES_TO_NAMES = {
     0: "BOOLEAN_TYPE",
@@ -62,6 +66,10 @@ class TTypeId:
     13: "UNION_TYPE",
     14: "USER_DEFINED_TYPE",
     15: "DECIMAL_TYPE",
+    16: "NULL_TYPE",
+    17: "DATE_TYPE",
+    18: "VARCHAR_TYPE",
+    19: "CHAR_TYPE"
   }
 
   _NAMES_TO_VALUES = {
@@ -81,6 +89,10 @@ class TTypeId:
     "UNION_TYPE": 13,
     "USER_DEFINED_TYPE": 14,
     "DECIMAL_TYPE": 15,
+    "NULL_TYPE": 16,
+    "DATE_TYPE": 17,
+    "VARCHAR_TYPE": 17,
+    "CHAR_TYPE": 18
   }
 
 class TStatusCode:


### PR DESCRIPTION
The newest version of Hive has some extra data types that are not included in the current pyhs2 package.
