### PR TITLE
add rpm requirements for thrift and sasl

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_rpm]
+requires = python >= 2.6 python-sasl python-thrift


### PR DESCRIPTION
As packager I would like to have the needed rpm dependencies in place. So that setup.py bdist_rpm produces a valid rpm with all dependencies needed to run.