### PR TITLE
Support unix domain sockets

### DIFF
--- a/pyhs2/connections.py
+++ b/pyhs2/connections.py
@@ -16,7 +16,7 @@ class Connection(object):
     client = None
     session = None
 
-    def __init__(self, host=None, port=10000, authMechanism=None, user=None, password=None, database=None, configuration=None, timeout=None):
+    def __init__(self, unix_socket=None, host=None, port=10000, authMechanism=None, user=None, password=None, database=None, configuration=None, timeout=None):
         authMechanisms = set(['NOSASL', 'PLAIN', 'KERBEROS', 'LDAP'])
         if authMechanism not in authMechanisms:
             raise NotImplementedError('authMechanism is either not supported or not implemented')
@@ -24,7 +24,10 @@ class Connection(object):
         #Open issue with python-sasl
         if authMechanism == 'PLAIN' and (password is None or len(password) == 0):
             password = 'password'
-        socket = TSocket(host, port)
+        if unix_socket is not None:
+            socket = TSocket(unix_socket=unix_socket)
+        else:
+            socket = TSocket(host, port)
         socket.setTimeout(timeout)
         if authMechanism == 'NOSASL':
             transport = TBufferedTransport(socket)


### PR DESCRIPTION
Allow connections over unix domain sockets.  If the `unix_socket` argument is provided to `connect()`, prefer using the unix domain socket.

Example

```python
with pyhs2.connect(unix_socket='/tmp/foo.sock',
                   authMechanism='PLAIN',
                   user='hive') as conn:
```