### PR TITLE
Modify cursor.fetchmany() to break after no results

### DIFF
--- a/pyhs2/cursor.py
+++ b/pyhs2/cursor.py
@@ -153,7 +153,10 @@ class Cursor(object):
            size = self.arraysize
         recs = []
         for i in range(0,size):
-            recs.append(self.fetchone())
+            rec = self.fetchone()
+            if rec is None:
+                break
+            recs.append(rec)
 
         self._cursorLock.release()
         return recs


### PR DESCRIPTION
Currently, if you call `cur.fetchmany(1000)` while there is only 1 row left to fetch, the loop will call `self.fetchone()` 1000 times and will return an array of size 1000, where 999 values are None. 

This file change breaks out of the loop if `self.fetchone()` returns None to prevent this behavior, exactly what `fetchall()` does.
