### PR TITLE
Convert str values to unicode in fetchone

### DIFF
--- a/pyhs2/cursor.py
+++ b/pyhs2/cursor.py
@@ -138,7 +138,7 @@ class Cursor(object):
 
         # return the first record
         self._cursorLock.release()
-        return self._currentBlock[0]
+        return [val.decode('utf-8') if isinstance(val, str) else val for val in self._currentBlock[0]]
 
     def fetchmany(self,size=-1):
         """ return a sequential set of records. This is guaranteed by locking, 


### PR DESCRIPTION
In Python2.7, fetchone() returns a row containing string, not unicode, values. This causes an error in my Flask application's templating system.
I'm not sure if this would be better handled in the downstream library
